### PR TITLE
assert.array('var', null || undefined) throws wrong error

### DIFF
--- a/src/common-assert.js
+++ b/src/common-assert.js
@@ -53,7 +53,7 @@ function arrayCheck(name, value) {
   if(!Array.isArray(value)) {
     throw new AssertionError({
       message: `${name} should be an array`,
-      actual: value.toString(),
+      actual: value,
       expected: 'Array',
       operation: 'array',
       stackStartFunction: 'array'

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -329,6 +329,18 @@ describe('Assert', function() {
       }).to.throw('test should be an array');
     });
 
+    it('should throw an assertion error for null values', function() {
+      expect(function() {
+        assert.array('test', null);
+      }).to.throw('test should be an array');
+    });
+
+    it('should throw an assertion error for undefined values', function() {
+      expect(function() {
+        assert.array('test', undefined);
+      }).to.throw('test should be an array');
+    });
+
   });
 
   describe('#func', function() {


### PR DESCRIPTION
Fixed a bug that would cause assert.array given null or undefined to throw the wrong error. #14