### PR TITLE
V1.1.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["add-module-exports"]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015"],
+  "presets": ["es2015-node4"],
   "plugins": ["add-module-exports"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,12 @@
 {
-  "env":{
+  "env": {
     "node": true,
-    "amd": true,
     "es6": true
   },
-  "ecmaFeatures": {
-    "modules": true
+  "parserOptions": {
+    "sourceType": "module"
   },
-  "rules":{
+  "rules": {
     "block-scoped-var": 2,
     "no-use-before-define": 2,
     "space-in-parens": [2, "never"],

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ coverage/
 CONTRIBUTING.md
 wallaby.config.js
 scripts/
+.babelrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-- '2.5'
-- '3.0'
 - '4.2'
 - '5.7'
 notifications:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ assert.string('myVar', ' something ').notWhiteSpace(); // Safe
 assert.string('myVar', ' ').notWhiteSpace(); // AssertionError: myVar should be a non white space only string
 ```
 
+#### #uuid() (also guid())
+Validates your string is a UUID/GUID. Throws an assertion error otherwise.
+```js
+assert.string('myVar', 'a4558b56-af55-47e4-9980-28b29e4f81ef').uuid() // Safe
+assert.string('myVar', 'a4558b56-af55-47e4-9980-28b29e4f81ef').guid() // Safe
+assert.string('myVar', 'definitely-not-a-uuid').uuid() // AssertionError: myVar should be a UUID
+```
+
 ### Number
 The number assertion helps you validate certain properties against numbers.
 ```js
@@ -201,6 +209,7 @@ assert.number('myVar', 0).negative() // AssertionError: myVar should be a negati
 Since boolean values are so simple, there are no use cases for assertion chains on booleans.
 ```js
 assert.bool('myVar', true); // Safe
+assert.boolean('myVar', true); // Safe
 assert.bool('myVar', {}); // AssertionError: myVar should be of type boolean
 ```
 
@@ -255,6 +264,7 @@ assert.array('myVar', [1, 2, 3]).contains(4); // AssertionError: myVar should co
 ### Function
 Functions are another of those simple types in js, so currently no useful assertions can be made of functions
 ```js
+assert.func('myVar', function() {});
 assert.function('myVar', function() {});
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 fluent-assert is meant to be a better way of specifying your contract signatures, allowing you to fluently make your assertions for not only types, but different properties of those types.
 
-## Getting Started
+## Getting Started (Recommended Node >=4, works with iojs >=2.5)
 First install through npm
 
 `npm install --save fluent-assert`
@@ -60,7 +60,7 @@ assert.custom('myVar', 5, value => value === 6); // AssertionError: myVar should
 ```
 
 #### #optional()
-Allows all type assertions (not including those mentioned above) to allow undefined values. The optional flag will be applied throughout the entire assertion chain, so you can still make an assertion without if the value is present
+Allows all type assertions (not including those mentioned above) to allow undefined values. The optional flag will be applied throughout the entire assertion chain, so you can still make an assertion without the value being present.
 ```js
 assert.optional().string(undefined).matches(/[A-Z]*/); // Safe
 ```
@@ -163,6 +163,22 @@ assert.number('myVar', 10).finite(); // Safe
 assert.number('myVar', Infinity).finite() // AssertionError: myVar should be a finite number
 assert.number('myVar', -Infinity).finite() // AssertionError: myVar should be a finite number
 assert.number('myVar', NaN).finite() // AssertionError: myVar should be a finite number
+```
+
+#### #positive()
+Validates your value is a positive number. Throws an assertion error if your value is <= 0
+```js
+assert.number('myVar', 10).positive() // Safe
+assert.number('myVar', -10).positive() // AssertionError: myVar should be a positive number
+assert.number('myVar', 0).positive() // AssertionError: myVar should be a positive number
+```
+
+#### #negative()
+Validates your value is a negative number. Throws an assertion error if your value is >= 0
+```js
+assert.number('myVar', -10).negative() // Safe
+assert.number('myVar', 10).negative() // AssertionError: myVar should be a negative number
+assert.number('myVar', 0).negative() // AssertionError: myVar should be a negative number
 ```
 
 ### Boolean

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Allows all type assertions (not including those mentioned above) to allow undefi
 ```js
 assert.optional().string(undefined).matches(/[A-Z]*/); // Safe
 ```
-*Note* Once the optional function has been called, the chain will no longer have an optional function, so something like `assert.optional().optioanl()` will result in an error.
+*Note* Once the optional function has been called, the chain will no longer have an optional function, so something like `assert.optional().optional()` will result in an error.
 
 ### String
 The string assertion utility has some useful functions for validating the contract on string parameters.
@@ -154,6 +154,15 @@ Validates your value is within an array of given values. Throws an assertion err
 ```js
 assert.number('myVar', 10).in([2, 4, 6, 8 ,10]); // Safe
 assert.number('myVar', 10).in([1, 3, 5, 7, 9]); // AssertionError: myVar should be in [1, 3, 5, 7, 9]
+```
+
+#### #finite()
+Validates your value is a number of a finite value. Throws an assertion error otherwise
+```js
+assert.number('myVar', 10).finite(); // Safe
+assert.number('myVar', Infinity).finite() // AssertionError: myVar should be a finite number
+assert.number('myVar', -Infinity).finite() // AssertionError: myVar should be a finite number
+assert.number('myVar', NaN).finite() // AssertionError: myVar should be a finite number
 ```
 
 ### Boolean

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 fluent-assert is meant to be a better way of specifying your contract signatures, allowing you to fluently make your assertions for not only types, but different properties of those types.
 
-## Getting Started (Recommended Node >=4, works with iojs >=2.5)
+## Getting Started (Required Node >=4)
 First install through npm
 
 `npm install --save fluent-assert`

--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ assert.number('myVar', -10).positive() // AssertionError: myVar should be a posi
 assert.number('myVar', 0).positive() // AssertionError: myVar should be a positive number
 ```
 
+#### #integer()
+Validate your value is an integer. Throws an assertion error if your value is a float
+```js
+assert.number('myVar', 10).integer() // Safe
+assert.number('myVar', 10.0).integer() // Safe
+assert.number('myVar', 10.1).integer() // AssertionError: myVar should be an float
+```
+
+#### #float()
+Validate your value is a float. Throws an assertion error if your value is evaluated as a whole number
+```js
+assert.number('myVar', 10.1).float() // Safe
+assert.number('myVar', 10).float() // AssertionError: myVar should be a float
+assert.number('myVar', 10.0).float() // AssertionError: myVar should be a float
+```
+
 #### #negative()
 Validates your value is a negative number. Throws an assertion error if your value is >= 0
 ```js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "Fluent assertions for javascript types.",
   "repository": "http://github.com/zack37/fluent-assert",
+  "engines": {
+    "node": ">=4",
+    "iojs": ">=2.5"
+  },
   "main": "index.js",
   "scripts": {
     "test": "mocha --compilers js:babel-core/register test/*-spec.js",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.2",
     "babel-plugin-add-module-exports": "^0.1.2",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2015-node4": "^2.0.3",
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",
     "eslint": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "preversion": "./scripts/check_branch.sh",
     "postversion": "git push origin master --tags",
     "coverage": "istanbul cover node_modules/.bin/_mocha -- -R list --compilers js:babel-core/register test/*-spec.js",
-    "ci": "npm run lint && npm run coverage && istanbul check-coverage -s 100 -f 100 -b 100 -l 100"
+    "ci": "npm run lint && npm run coverage && istanbul"
   },
   "keywords": [
     "assert",

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "repository": "http://github.com/zack37/fluent-assert",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel/register test/*-spec.js",
+    "test": "mocha --compilers js:babel-core/register test/*-spec.js",
     "tw": "npm test -- --watch --bail -R min",
     "prepublish": "npm run compile",
     "compile": "babel -d lib/ src/",
     "lint": "esw --quiet",
     "preversion": "./scripts/check_branch.sh",
     "postversion": "git push origin master --tags",
-    "coverage": "istanbul cover node_modules/.bin/_mocha -- -R list --compilers js:babel/register test/*-spec.js",
-    "ci": "npm run lint && npm run coverage && istanbul check-coverage -s 95 -f 95 -b 95 -l 95"
+    "coverage": "istanbul cover node_modules/.bin/_mocha -- -R list --compilers js:babel-core/register test/*-spec.js",
+    "ci": "npm run lint && npm run coverage && istanbul check-coverage -s 100 -f 100 -b 100 -l 100"
   },
   "keywords": [
     "assert",
@@ -23,12 +23,15 @@
   "author": "Zack Smith",
   "license": "ISC",
   "devDependencies": {
-    "babel": "^5.8.21",
-    "chai": "^3.4.0",
-    "eslint": "^1.7.3",
-    "eslint-watch": "^2.1.2",
-    "istanbul": "^0.4.0",
-    "mocha": "^2.3.3",
-    "wallaby-webpack": "0.0.10"
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.2",
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-register": "^6.7.2",
+    "chai": "^3.5.0",
+    "eslint": "^2.4.0",
+    "eslint-watch": "^2.1.10",
+    "istanbul": "1.0.0-alpha.2",
+    "mocha": "^2.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Fluent assertions for javascript types.",
   "repository": "http://github.com/zack37/fluent-assert",
   "engines": {
-    "node": ">=4",
-    "iojs": ">=2.5"
+    "node": ">=4"
   },
   "main": "index.js",
   "scripts": {
@@ -17,7 +16,7 @@
     "preversion": "./scripts/check_branch.sh",
     "postversion": "git push origin master --tags",
     "coverage": "istanbul cover node_modules/.bin/_mocha -- -R list --compilers js:babel-core/register test/*-spec.js",
-    "ci": "npm run lint && npm run coverage && istanbul"
+    "ci": "npm run lint && npm run coverage"
   },
   "keywords": [
     "assert",

--- a/src/array-assert.js
+++ b/src/array-assert.js
@@ -3,8 +3,8 @@ import common from './common-assert'
 export default (name, value, optional) => {
   common.optional(optional, value, () => common.arrayCheck(name, value));
 
-  let assert = {};
-  let emptyFunction = () => assert;
+  const assert = {};
+  const emptyFunction = () => assert;
 
   assert.of = common.optional(optional, value, () => type => {
     let inner = common.isType(type, 'string')

--- a/src/common-assert.js
+++ b/src/common-assert.js
@@ -9,9 +9,10 @@ const runningMode = process.env.NODE_ENV || 'debug';
  * @param {String} type - The type to test against as a string
  * @returns {boolean}
  */
-function isType(value, type) {
-  return runningMode === 'production' || typeof value === type;
-}
+/* istanbul ignore next */
+const isType = runningMode === 'production'
+  ? () => true
+  : (value, type) => typeof value === type;
 
 /**
  * Helper function to throw assertion error
@@ -20,7 +21,7 @@ function isType(value, type) {
  * @param message - Message for user consumption
  * @param func - Start stack function
  */
-function error(actual, expected, message, func) {
+const error = (actual, expected, message, func) => {
   throw new AssertionError({
     message,
     actual,
@@ -28,7 +29,7 @@ function error(actual, expected, message, func) {
     operation: func,
     stackStartFunction: func
   });
-}
+};
 
 /**
  * Checks value against type using `typeof`
@@ -37,14 +38,15 @@ function error(actual, expected, message, func) {
  * @param {String} type - type to check value against
  * @throws {AssertionError} - Throws error if value is not of type
  */
-function typeCheck(name, value, type) {
+/* istanbul ignore next */
+const typeCheck = (name, value, type) => {
   if(!isType(value, type)) {
     error(typeof value,
       type,
       `${name} should be of type ${type}`,
       'type');
   }
-}
+};
 
 /**
  * Checks if value is an array
@@ -52,14 +54,14 @@ function typeCheck(name, value, type) {
  * @param {Object} value - value to check
  * @throws {AssertionError} - Throws error if value is not an array
  */
-function arrayCheck(name, value) {
+const arrayCheck = (name, value) => {
   if(!Array.isArray(value)) {
     error(value,
       'Array',
       `${name} should be an array`,
       'arrayCheck');
   }
-}
+};
 
 /**
  * Helper wrapper function for optional value checking
@@ -69,11 +71,11 @@ function arrayCheck(name, value) {
  * @param {*} [fallback] - Fallback value if optional value checking fails
  * @returns {*} - Value of callback function
  */
-function optional(isOptional, value, cb, fallback) {
+const optional = (isOptional, value, cb, fallback) => {
   return !isOptional || (value !== null && value !== undefined)
     ? cb()
     : fallback;
-}
+};
 
 /**
  * Similar to typeCheck, but uses the Object toString to grab the type for
@@ -84,7 +86,7 @@ function optional(isOptional, value, cb, fallback) {
  * @param {String} expectedType - The expected type as a string
  * @throws {AssertionError} - Throws error if value is not of type expectedType
  */
-function toStringCheck(name, value, expectedType) {
+const toStringCheck = (name, value, expectedType) => {
   let objToString = Object.prototype.toString.call(value);
   let regexp = new RegExp(expectedType, 'i');
   if(!regexp.test(objToString)) {
@@ -93,7 +95,7 @@ function toStringCheck(name, value, expectedType) {
       `${name} should be of type ${expectedType}`,
       'toStringCheck');
   }
-}
+};
 
 export default {
   typeCheck,

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function baseAssertGenerator(isOptional) {
    * @param {Object} value - The value being tested
    * @throws {AssertionError} - If value is not a boolean
    */
-  assert.bool = (name, value) => {
+  assert.bool = assert.boolean = (name, value) => {
     common.optional(isOptional, value, () =>
       common.typeCheck(name, value, 'boolean')
     );
@@ -85,7 +85,7 @@ function baseAssertGenerator(isOptional) {
    * @param {Object} value - The value being tested
    * @throws {AssertionError} - If value is not a function
    */
-  assert.func = (name, value) => {
+  assert.func = assert.function = (name, value) => {
     common.optional(isOptional, value, () =>
       common.typeCheck(name, value, 'function')
     );
@@ -126,7 +126,7 @@ function baseAssertGenerator(isOptional) {
   };
 
   /**
-   * Asserts if the value being passed in is a number
+   * Asserts if the value being passed in matches the given predicate function
    * @param {String} name - The name of the value being tested
    * @param {Object} value - The value being tested
    * @param {Function} predicate - Predicate function to test value against

--- a/src/number-assert.js
+++ b/src/number-assert.js
@@ -111,7 +111,7 @@ export default (name, value, optional) => {
   }, emptyFunction);
 
   /**
-   * Tests if value is ina  subset of numbers
+   * Tests if value is in a subset of numbers
    * @param {Array.<Number>} values - Subset of numbers to confine value
    * @returns {NumberAssert}
    * @throws {AssertionError} - Throws error if value is not contained in values
@@ -127,12 +127,77 @@ export default (name, value, optional) => {
     return assert;
   }, emptyFunction);
 
+  /**
+   * Tests if value is a finite number
+   * @returns {NumberAssert}
+   * @throws {AssertionError} - Throws error if value is not finite or is NaN
+   */
   assert.finite = common.optional(optional, value, () => () => {
     if(isNaN(value) || !isFinite(value)) {
       common.error(value,
         `${value} to be a finite number`,
         `${name} should be a finite number`,
         'finite');
+    }
+    return assert;
+  }, emptyFunction);
+
+  /**
+   * Tests if value is an integer
+   * @returns {NumberAssert}
+   * @throws {AssertionError} - Throws error if value is not an integer
+   */
+  assert.integer = common.optional(optional, value, () => () => {
+    if(value % 1 !== 0) {
+      common.error(value,
+        `${value} to be an integer`,
+        `${name} should be an integer`,
+        'integer');
+    }
+    return assert;
+  }, emptyFunction);
+
+  /**
+   * Tests if value is a float
+   * @returns {NumberAssert}
+   * @throws {AssertionError} - Throws error if value is not a float
+   */
+  assert.float = common.optional(optional, value, () => () => {
+    if(value % 1 === 0) {
+      common.error(value,
+        `${value} to be a float`,
+        `${name} should be a float`,
+        'float');
+    }
+    return assert;
+  }, emptyFunction);
+
+  /**
+   * Tests if value is a positive number
+   * @returns {NumberAssert}
+   * @throws {AssertionError} - Throws error if value is not a positive number
+   */
+  assert.positive = common.optional(optional, value, () => () => {
+    if(value <= 0) {
+      common.error(value,
+        `${value} to be a positive number`,
+        `${name} should be a positive number`,
+        'positive');
+    }
+    return assert;
+  }, emptyFunction);
+
+  /**
+   * Tests if value is a negative number
+   * @returns {NumberAssert}
+   * @throws {AssertionError} - Throws error if value is not a negative number
+   */
+  assert.negative = common.optional(optional, value, () => () => {
+    if(value >= 0) {
+      common.error(value,
+        `${value} to be a negative number`,
+        `${name} should be a negative number`,
+        'negative');
     }
     return assert;
   }, emptyFunction);

--- a/src/number-assert.js
+++ b/src/number-assert.js
@@ -127,5 +127,15 @@ export default (name, value, optional) => {
     return assert;
   }, emptyFunction);
 
+  assert.finite = common.optional(optional, value, () => () => {
+    if(isNaN(value) || !isFinite(value)) {
+      common.error(value,
+        `${value} to be a finite number`,
+        `${name} should be a finite number`,
+        'finite');
+    }
+    return assert;
+  }, emptyFunction);
+
   return assert;
 };

--- a/src/string-assert.js
+++ b/src/string-assert.js
@@ -68,5 +68,15 @@ export default (name, value, optional) => {
     return assert;
   }, emptyFunction);
 
+  assert.uuid = assert.guid = common.optional(optional, value, () => () => {
+    if (!/[a-z0-9]{8}-?[a-z0-9]{4}-?[a-z0-9]{4}-?[a-z0-9]{4}-?[a-z0-9]{12}/i.test(value)) {
+      common.error(value,
+        'a UUID',
+        `${name} should be a UUID`,
+        'uuid');
+    }
+    return assert;
+  }, emptyFunction);
+
   return assert;
 };

--- a/test/array-assert-spec.js
+++ b/test/array-assert-spec.js
@@ -1,7 +1,6 @@
-'use strict';
+import { expect } from 'chai';
 
-var expect = require('chai').expect;
-var arrayAssert = require('../src/array-assert');
+import arrayAssert from '../src/array-assert';
 
 describe('arrayAssert', function() {
 

--- a/test/common-assert-spec.js
+++ b/test/common-assert-spec.js
@@ -1,0 +1,109 @@
+import { expect } from 'chai';
+
+import commonAssert from '../src/common-assert';
+
+describe('common assert', () => {
+
+  describe('#isType', () => {
+
+    beforeEach(() => {
+      process.env.NODE_ENV = undefined;
+      Object.keys(require.cache).filter(x => x.includes('common-assert')).forEach(x => delete require.cache[x]);
+    });
+
+    it('should create dummy function when NODE_ENV === production', () => {
+      process.env.NODE_ENV = 'production';
+      const ca = require('../src/common-assert');
+      expect(ca.isType(true, 'boolean')).to.be.true;
+      expect(ca.isType(true, 'string')).to.be.true;
+    });
+
+    it('should verify value is of type', () => {
+      const ca = require('../src/common-assert');
+      expect(ca.isType(true, 'boolean')).to.be.true;
+      expect(ca.isType(true, 'string')).to.be.false;
+    });
+
+  });
+
+  describe('#optional', () => {
+    let callback, fallback;
+
+    beforeEach(() => {
+      callback = () => 'callback';
+      fallback = 'fallback';
+    });
+
+    it('should return callback value if not optional', () => {
+      expect(commonAssert.optional(false, 'value', callback, fallback)).to.equal('callback');
+    });
+
+    it('should return callback value if optional and value exists', () => {
+      expect(commonAssert.optional(true, 'value', callback, fallback)).to.equal('callback');
+    });
+
+    it('should return fallback value if optional and value is null', () => {
+      expect(commonAssert.optional(true, null, callback, fallback)).to.equal('fallback');
+    });
+
+    it('should return callback value if optional and value is undefined', () => {
+      expect(commonAssert.optional(true, undefined, callback, fallback)).to.equal('fallback');
+    });
+
+  });
+
+  describe('#toStringCheck', () => {
+
+    it('should throw an error when object is not of type value', () => {
+      expect(() => {
+        commonAssert.toStringCheck('test', new Date(), 'String');
+      }).to.throw('test should be of type String');
+    });
+
+    it('should not throw an error when object is of type value', () => {
+      expect(() => {
+        commonAssert.toStringCheck('test', new Date(), 'Date');
+      }).to.not.throw();
+    });
+
+    it('should not throw an error when object is of type value (case insensitive)', () => {
+      expect(() => {
+        commonAssert.toStringCheck('test', new Date(), 'date');
+      }).to.not.throw();
+    });
+
+  });
+
+  describe('#typeCheck', () => {
+
+    it('should throw an error when value is not of type', () => {
+      expect(() => {
+        commonAssert.typeCheck('test', true, 'number');
+      }).to.throw('test should be of type number');
+    });
+
+    it('should not throw an error when value is of type', () => {
+      expect(() => {
+        commonAssert.typeCheck('test', true, 'boolean');
+      }).to.not.throw();
+    });
+
+  });
+
+  describe('#arrayCheck', () => {
+
+    it('should throw an error when value is not an array', () => {
+      expect(() => {
+        commonAssert.arrayCheck('test', {});
+      }).to.throw('test should be an array');
+    });
+
+    it('should not throw an error when value is an array', () => {
+      expect(() => {
+        commonAssert.arrayCheck('test', []);
+      }).to.not.throw();
+    });
+
+  });
+
+});

--- a/test/date-assert-spec.js
+++ b/test/date-assert-spec.js
@@ -1,7 +1,6 @@
-'use strict';
+import { expect } from 'chai';
 
-var expect = require('chai').expect;
-var dateAssert = require('../src/date-assert');
+import dateAssert from '../src/date-assert';
 
 describe('dateAssert', function() {
 

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -1,19 +1,16 @@
-'use strict';
+import { expect } from 'chai';
 
-var expect = require('chai').expect;
-var assert = require('../src/index');
+import assert from '../src';
 
 describe('Assert', function() {
 
   describe('#optional', function() {
 
     it('should not allow multiple calls to optional', () => {
-      expect(function() {
-        assert.optional().optional();
-      }).to.throw('assert.optional(...).optional is not a function');
+      expect(assert.optional().optional).to.be.undefined;
     });
 
-    describe('boolean', function() {
+    describe('bool', function() {
 
       it('should not throw an error for an undefined argument', function() {
         expect(function() {
@@ -75,7 +72,7 @@ describe('Assert', function() {
 
     });
 
-    describe('function', function() {
+    describe('func', function() {
 
       it('should not throw an error for undefined value', function() {
         expect(function() {
@@ -338,7 +335,12 @@ describe('Assert', function() {
 
   });
 
-  describe('#boolean', function() {
+  describe('#bool', function() {
+
+    it('should have alias "boolean"', () => {
+      expect(assert.boolean).to.be.a('function');
+      expect(assert.boolean).to.eql(assert.bool);
+    });
 
     it('should not throw an error when creating a boolean validator for a boolean', function() {
       expect(function() {
@@ -383,6 +385,11 @@ describe('Assert', function() {
   });
 
   describe('#func', function() {
+
+    it('should have alias "function"', () => {
+      expect(assert.function).to.be.a('function');
+      expect(assert.function).to.eql(assert.func);
+    });
 
     it('should throw an error when value if not a function', function() {
       expect(function() {

--- a/test/number-assert-spec.js
+++ b/test/number-assert-spec.js
@@ -1,216 +1,254 @@
-'use strict';
+import { expect } from 'chai';
 
-var expect = require('chai').expect;
-var numberAssert = require('../src/number-assert');
+import numberAssert from '../src/number-assert';
 
-describe('numberAssert', function() {
+describe('numberAssert', () => {
 
-  describe('#min', function() {
+  describe('#min', () => {
 
-    it('should throw an error when validating a number smaller than "min"', function() {
-      var na = numberAssert('test', 0);
-      expect(function() {
+    it('should throw an error when validating a number smaller than "min"', () => {
+      const na = numberAssert('test', 0);
+      expect(() => {
         na.min(100);
       }).to.throw('test should be greater than 100');
     });
 
-    it('should not throw an error when validating a number larger than "min"', function() {
-      var na = numberAssert('test', 100);
-      expect(function() {
+    it('should not throw an error when validating a number larger than "min"', () => {
+      const na = numberAssert('test', 100);
+      expect(() => {
         na.min(0);
       }).to.not.throw('test should be greater than 0');
     });
 
-    it('should not throw an error for value same as "min"', function() {
-      var na = numberAssert('test', 0);
-      expect(function() {
+    it('should not throw an error for value same as "min"', () => {
+      const na = numberAssert('test', 0);
+      expect(() => {
         na.min(0);
       }).to.not.throw('test should be greater than 0');
     });
 
-    it('should return a numberAssert', function() {
-      var na = numberAssert('test', 0);
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 0);
       expect(na.min(0)).to.be.an.instanceOf(Object);
     });
 
   });
 
-  describe('#max', function() {
+  describe('#max', () => {
 
-    it('should throw an error when validating a number larger than "max"', function() {
-      var na = numberAssert('test', 100);
-      expect(function() {
+    it('should throw an error when validating a number larger than "max"', () => {
+      const na = numberAssert('test', 100);
+      expect(() => {
         na.max(0);
       }).to.throw('test should be less than 0');
     });
 
-    it('should not throw an error when validating a number smaller than "max"', function() {
-      var na = numberAssert('test', 0);
-      expect(function() {
+    it('should not throw an error when validating a number smaller than "max"', () => {
+      const na = numberAssert('test', 0);
+      expect(() => {
         na.max(100);
       }).to.not.throw('test should be less than 100');
     });
 
-    it('should not throw an error for value same as "max"', function() {
-      var na = numberAssert('test', 100);
-      expect(function() {
+    it('should not throw an error for value same as "max"', () => {
+      const na = numberAssert('test', 100);
+      expect(() => {
         na.max(100);
       }).to.not.throw('test should be less than 100');
     });
 
-    it('should return a numberAssert', function() {
-      var na = numberAssert('test', 0);
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 0);
       expect(na.max(0)).to.be.an.instanceOf(Object);
     });
 
   });
 
-  describe('#range', function() {
+  describe('#range', () => {
 
-    it('should throw an error when lower bound rule is violated', function() {
-      var na = numberAssert('test', 0);
-      expect(function() {
+    it('should throw an error when lower bound rule is violated', () => {
+      const na = numberAssert('test', 0);
+      expect(() => {
         na.range(1, 10);
       }).to.throw('test should be between 1 and 10');
     });
 
-    it('should throw an error when upper bound rule is violated', function() {
-      var na = numberAssert('test', 100);
-      expect(function() {
+    it('should throw an error when upper bound rule is violated', () => {
+      const na = numberAssert('test', 100);
+      expect(() => {
         na.range(1, 10);
       }).to.throw('test should be between 1 and 10');
     });
 
-    it('should not throw an error when value is the same as the lower bound', function() {
-      var na = numberAssert('test', 10);
-      expect(function() {
+    it('should not throw an error when value is the same as the lower bound', () => {
+      const na = numberAssert('test', 10);
+      expect(() => {
         na.range(10, 100);
       }).to.not.throw('test should be between 10 and 100');
     });
 
-    it('should not throw an error when value is the same as the upper bound rule', function() {
-      var na = numberAssert('test', 10);
-      expect(function() {
+    it('should not throw an error when value is the same as the upper bound rule', () => {
+      const na = numberAssert('test', 10);
+      expect(() => {
         na.range(1, 10);
       }).to.not.throw('test should be between 1 and 10');
     });
 
-    it('should not throw an error when value passed to numberAssert lies within lower and upper bound', function() {
-      var na = numberAssert('test', 5);
-      expect(function() {
+    it('should not throw an error when value passed to numberAssert lies within lower and upper bound', () => {
+      const na = numberAssert('test', 5);
+      expect(() => {
         na.range(1, 10);
       }).to.not.throw('test should be between 1 and 10');
     });
 
-    it('should return a numberAssert', function() {
-      var na = numberAssert('test', 0);
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 0);
       expect(na.range(0, 10)).to.be.an.instanceOf(Object);
     });
 
   });
 
-  describe('#even', function() {
+  describe('#even', () => {
 
-    it('should throw an error for odd numbers', function() {
-      var na = numberAssert('test', 5);
-      expect(function() {
+    it('should throw an error for odd numbers', () => {
+      const na = numberAssert('test', 5);
+      expect(() => {
         na.even();
       }).to.throw('test should be even');
     });
 
-    it('should not throw an error for even numbers', function() {
-      var na = numberAssert('test', 6);
-      expect(function() {
+    it('should not throw an error for even numbers', () => {
+      const na = numberAssert('test', 6);
+      expect(() => {
         na.even();
       }).to.not.throw('test should be even');
     });
 
-    it('should return a numberAssert', function() {
-      var na = numberAssert('test', 0);
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 0);
       expect(na.even()).to.be.an.instanceOf(Object);
     });
 
   });
 
-  describe('#odd', function() {
+  describe('#odd', () => {
 
-    it('should throw an error for even numbers', function() {
-      var na = numberAssert('test', 6);
-      expect(function() {
+    it('should throw an error for even numbers', () => {
+      const na = numberAssert('test', 6);
+      expect(() => {
         na.odd();
       }).to.throw('test should be odd');
     });
 
-    it('should not throw an error for odd numbers', function() {
-      var na = numberAssert('test', 5);
-      expect(function() {
+    it('should not throw an error for odd numbers', () => {
+      const na = numberAssert('test', 5);
+      expect(() => {
         na.odd();
       }).to.not.throw('test should be odd');
     });
 
-    it('should return a numberAssert', function() {
-      var na = numberAssert('test', 1);
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 1);
       expect(na.odd()).to.be.an.instanceOf(Object);
     });
 
   });
 
-  describe('#equal', function() {
+  describe('#equal', () => {
 
-    it('should throw an error when value is greater than compare', function() {
-      var na = numberAssert('test', 10);
-      expect(function() {
+    it('should throw an error when value is greater than compare', () => {
+      const na = numberAssert('test', 10);
+      expect(() => {
         na.equal(0);
       }).to.throw('test should be equal to 0');
     });
 
-    it('should throw an error when value is less than compare', function() {
-      var na = numberAssert('test', 10);
-      expect(function() {
+    it('should throw an error when value is less than compare', () => {
+      const na = numberAssert('test', 10);
+      expect(() => {
         na.equal(100);
       }).to.throw('test should be equal to 100');
     });
 
-    it('should not throw an error when value is equal to compare', function() {
-      var na = numberAssert('test', 10);
-      expect(function() {
+    it('should not throw an error when value is equal to compare', () => {
+      const na = numberAssert('test', 10);
+      expect(() => {
         na.equal(10);
       }).to.not.throw('test should be equal to 10');
     });
 
-    it('should return a numberAssert', function() {
-      var na = numberAssert('test', 0);
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 0);
       expect(na.equal(0)).to.be.an.instanceOf(Object);
     });
 
   });
 
-  describe('#in', function() {
+  describe('#in', () => {
 
-    it('should throw an error when parameter values is not an array', function() {
-      var na = numberAssert('test', 0);
-      expect(function() {
+    it('should throw an error when parameter values is not an array', () => {
+      const na = numberAssert('test', 0);
+      expect(() => {
         na.in([1, 2, 3, 4, 5]);
       }).to.throw('test should be in 1,2,3,4,5');
     });
 
-    it('should throw an error when value is not present in parameter values', function() {
-      var na = numberAssert('test', 0);
-      expect(function() {
+    it('should throw an error when value is not present in parameter values', () => {
+      const na = numberAssert('test', 0);
+      expect(() => {
         na.in([1, 2, 3, 4, 5]);
       }).to.throw('test should be in 1,2,3,4,5');
     });
 
-    it('should not throw an error when value is present in parameter values', function() {
-      var na = numberAssert('test', 0);
-      expect(function() {
+    it('should not throw an error when value is present in parameter values', () => {
+      const na = numberAssert('test', 0);
+      expect(() => {
         na.in([0, 1, 2, 3, 4, 5]);
       }).to.not.throw('test should be in 1,2,3,4,5');
     });
 
-    it('should return a numberAssert', function() {
-      var na = numberAssert('test', 0);
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 0);
       expect(na.in([0])).to.be.an.instanceOf(Object);
+    });
+
+  });
+
+  describe('#finite', () => {
+
+    it('should not throw an error for a positive number', () => {
+      const na = numberAssert('test', 100);
+      expect(na.finite).to.not.throw();
+    });
+
+    it('should not throw an error for a negative number', () => {
+      const na = numberAssert('test', -100);
+      expect(na.finite).to.not.throw();
+    });
+
+    it('should not throw an error for a decimal number', () => {
+      const na = numberAssert('test', 1.10);
+      expect(na.finite).to.not.throw();
+    });
+
+    it('should not throw an error for a 0', () => {
+      const na = numberAssert('test', 0);
+      expect(na.finite).to.not.throw();
+    });
+
+    it('should throw an error for positive infinity', () => {
+      const na = numberAssert('test', Infinity);
+      expect(na.finite).to.throw('test should be a finite number');
+    });
+
+    it('should throw an error for negative infinity', () => {
+      const na = numberAssert('test', -Infinity);
+      expect(na.finite).to.throw('test should be a finite number');
+    });
+
+    it('should throw an error for NaN', () => {
+      const na = numberAssert('test', NaN);
+      expect(na.finite).to.throw('test should be a finite number');
     });
 
   });

--- a/test/number-assert-spec.js
+++ b/test/number-assert-spec.js
@@ -251,6 +251,97 @@ describe('numberAssert', () => {
       expect(na.finite).to.throw('test should be a finite number');
     });
 
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 0);
+      expect(na.finite()).to.be.an.instanceOf(Object);
+    });
+
+  });
+
+  describe('#integer', () => {
+
+    it('should not throw an error for an integer value', () => {
+      const na = numberAssert('test', 10);
+      expect(na.integer).to.not.throw();
+    });
+
+    it('should throw an error for a float value', () => {
+      const na = numberAssert('test', 10.1);
+      expect(na.integer).to.throw('test should be an integer');
+    });
+
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 0);
+      expect(na.finite()).to.be.an.instanceOf(Object);
+    });
+
+  });
+
+  describe('#float', () => {
+
+    it('should not throw an error for a float value', () => {
+      const na = numberAssert('test', 10.1);
+      expect(na.float).to.not.throw();
+    });
+
+    it('should throw an error for an integer value', () => {
+      const na = numberAssert('test', 10);
+      expect(na.float).to.throw('test should be a float');
+    });
+
+    it('should return a numberAssert', () => {
+      const na = numberAssert('test', 0);
+      expect(na.finite()).to.be.an.instanceOf(Object);
+    });
+
+  });
+
+  describe('positive', () => {
+
+    it('should not throw an error for a positive number', () => {
+      const na = numberAssert('test', 10);
+      expect(na.positive).to.not.throw();
+    });
+
+    it('should throw an error for a negative number', () => {
+      const na = numberAssert('test', -10);
+      expect(na.positive).to.throw('test should be a positive number');
+    });
+
+    it('should throw an error for a zero (0) value', () => {
+      const na = numberAssert('test', 0);
+      expect(na.positive).to.throw('test should be a positive number');
+    });
+
+    it('should return an instance of numberAssert', () => {
+      const na = numberAssert('test', 10);
+      expect(na.positive()).to.be.an.instanceOf(Object);
+    });
+
+  });
+
+  describe('negative', () => {
+
+    it('should not throw an error for a negative number', () => {
+      const na = numberAssert('test', -10);
+      expect(na.negative).to.not.throw();
+    });
+
+    it('should throw an error for a positive number', () => {
+      const na = numberAssert('test', 10);
+      expect(na.negative).to.throw('test should be a negative number');
+    });
+
+    it('should throw an error for a zero (0) value', () => {
+      const na = numberAssert('test', 0);
+      expect(na.negative).to.throw('test should be a negative number');
+    });
+
+    it('should return an instance of numberAssert', () => {
+      const na = numberAssert('test', -10);
+      expect(na.negative()).to.be.an.instanceOf(Object);
+    })
+
   });
 
 });

--- a/test/object-assert-spec.js
+++ b/test/object-assert-spec.js
@@ -1,7 +1,6 @@
-'use strict';
+import { expect } from 'chai';
 
-var expect = require('chai').expect;
-var objectAssert = require('../src/object-assert');
+import objectAssert from '../src/object-assert';
 
 describe('objectAssert', function() {
 

--- a/test/string-assert-spec.js
+++ b/test/string-assert-spec.js
@@ -2,94 +2,149 @@ import { expect } from 'chai';
 
 import stringAssert from '../src/string-assert';
 
-describe('stringAssert', function() {
+describe('stringAssert', () => {
 
-  describe('#matches', function() {
+  describe('#matches', () => {
 
-    it('should throw an error when parameter is not of type RegExp', function() {
+    it('should throw an error when parameter is not of type RegExp', () => {
       var sa = stringAssert('test', 'test');
-      expect(function() {
+      expect(() => {
         sa.matches('test');
       }).to.throw('parameter regexp should be of type RegExp');
     });
 
-    it('should throw an error when value does not match pattern', function() {
+    it('should throw an error when value does not match pattern', () => {
       var sa = stringAssert('test', 'test');
-      expect(function() {
+      expect(() => {
         sa.matches(/fail/);
       }).to.throw('test should match pattern /fail/');
     });
 
-    it('should not throw an error when value matches pattern', function() {
+    it('should not throw an error when value matches pattern', () => {
       var sa = stringAssert('test', 'test');
-      expect(function() {
+      expect(() => {
         sa.matches(/test/);
       }).to.not.throw('test should match pattern /test/');
     });
 
-    it('should return a stringAssert', function() {
+    it('should return a stringAssert', () => {
       var sa = stringAssert('test', 'test');
       expect(sa.matches(/test/)).to.be.an.instanceOf(Object);
     });
 
   });
 
-  describe('#notEmpty', function() {
+  describe('#notEmpty', () => {
 
-    it('should throw an error when value is an empty string', function() {
+    it('should throw an error when value is an empty string', () => {
       var sa = stringAssert('test', '');
-      expect(function() {
+      expect(() => {
         sa.notEmpty();
       }).to.throw('test should not be empty');
     });
 
-    it('should return an instance of stringAssert', function() {
+    it('should return an instance of stringAssert', () => {
       var sa = stringAssert('test', 'test');
       expect(sa.notEmpty()).to.be.an.instanceOf(Object);
     });
 
-    it('should not throw an error when value is not an empty string', function() {
+    it('should not throw an error when value is not an empty string', () => {
       var sa = stringAssert('test', 'test');
-      expect(function() {
+      expect(() => {
         sa.notEmpty();
       }).to.not.throw('test should not be empty');
     });
 
   });
 
-  describe('#notWhiteSpace', function() {
+  describe('#notWhiteSpace', () => {
 
-    it('should throw an error when value is a white space string', function() {
+    it('should throw an error when value is a white space string', () => {
       var sa = stringAssert('test', '         \t');
-      expect(function() {
+      expect(() => {
         sa.notWhiteSpace();
       }).to.throw('test should not be whitespace');
     });
 
-    it('should throw an error when value is an empty string', function() {
+    it('should throw an error when value is an empty string', () => {
       var sa = stringAssert('test', '');
-      expect(function() {
+      expect(() => {
         sa.notWhiteSpace();
       }).to.throw('test should not be whitespace');
     });
 
-    it('should return an instance of stringAssert', function() {
+    it('should return an instance of stringAssert', () => {
       var sa = stringAssert('test', 'test');
       expect(sa.notWhiteSpace()).to.be.an.instanceOf(Object);
     });
 
-    it('should not throw an error when value is not a white space string', function() {
+    it('should not throw an error when value is not a white space string', () => {
       var sa = stringAssert('test', 'test');
-      expect(function() {
+      expect(() => {
         sa.notWhiteSpace();
       }).to.not.throw('test should not be whitespace');
     });
 
-    it('should not throw an error when value is not only whitespace', function() {
+    it('should not throw an error when value is not only whitespace', () => {
       var sa = stringAssert('test', ' test ');
-      expect(function() {
+      expect(() => {
         sa.notWhiteSpace();
       }).to.not.throw('test should not be whitespace');
+    });
+
+  });
+
+  describe('#uuid', () => {
+
+    it('should have an alias of guid', () => {
+      const sa = stringAssert('test', '');
+      expect(sa.guid).to.be.a('function');
+      expect(sa.guid).to.eql(sa.uuid);
+    });
+
+    it('should not throw an error for a well-formed UUID', () => {
+      const sa = stringAssert('test', 'a4558b56-af55-47e4-9980-28b29e4f81ef');
+      expect(sa.uuid).to.not.throw();
+    });
+
+    it('should not throw an error for missing first hyphen', () => {
+      const sa = stringAssert('test', 'a4558b56af55-47e4-9980-28b29e4f81ef');
+      expect(sa.uuid).to.not.throw();
+    });
+
+    it('should not throw an error for missing second hyphen', () => {
+      const sa = stringAssert('test', 'a4558b56-af5547e4-9980-28b29e4f81ef');
+      expect(sa.uuid).to.not.throw();
+    });
+
+    it('should not throw an error for missing third hyphen', () => {
+      const sa = stringAssert('test', 'a4558b56-af55-47e49980-28b29e4f81ef');
+      expect(sa.uuid).to.not.throw();
+    });
+
+    it('should not throw an error for missing fourth hyphen', () => {
+      const sa = stringAssert('test', 'a4558b56-af55-47e4-998028b29e4f81ef');
+      expect(sa.uuid).to.not.throw();
+    });
+
+    it('should not throw an error for missing all hyphens', () => {
+      const sa = stringAssert('test', 'a4558b56af5547e4998028b29e4f81ef');
+      expect(sa.uuid).to.not.throw();
+    });
+
+    it('should not throw an error for hex letter casing', () => {
+      const sa = stringAssert('test', 'A4558B56AF55-47E4-9980-28b29E4f81EF');
+      expect(sa.uuid).to.not.throw();
+    });
+
+    it('should throw an error for a malformed UUID', () => {
+      const sa = stringAssert('test', 'obviously-not-a-uuid');
+      expect(sa.uuid).to.throw('test should be a UUID');
+    });
+
+    it('should return an instance of stringAssert', () => {
+      const sa = stringAssert('test', 'a4558b56-af55-47e4-9980-28b29e4f81ef');
+      expect(sa.uuid()).to.be.an.instanceOf(Object);
     });
 
   });

--- a/test/string-assert-spec.js
+++ b/test/string-assert-spec.js
@@ -1,7 +1,6 @@
-'use strict';
+import { expect } from 'chai';
 
-var expect = require('chai').expect;
-var stringAssert = require('../src/string-assert');
+import stringAssert from '../src/string-assert';
 
 describe('stringAssert', function() {
 

--- a/wallaby.config.js
+++ b/wallaby.config.js
@@ -1,21 +1,18 @@
-var babel = require('babel');
-
 module.exports = function(wallaby) {
   return {
     files: [
-      'src/*.js',
-      'lib/*.js'
+      'src/*.js'
     ],
     tests: [
       'test/*-spec.js'
     ],
     env: {
-      type: 'node'
+      type: 'node',
+      runner: 'node'
     },
+    testFramework: 'mocha',
     compilers: {
-      'src/*.js': wallaby.compilers.babel({
-        babel: babel
-      })
+      '**/*.js': wallaby.compilers.babel()
     }
   };
 };


### PR DESCRIPTION
- Upgraded babel to v6
  - Uses node4 preset for more native features
- Removed support (didn't work anyways) for node <4
- Added Number assertions
  - finite
  - integer
  - float
  - positive
  - negative
- Added String assertions
  - uuid/guid
- Added aliases for bool(ean) and func(tion)
